### PR TITLE
Speedup autosuggestion

### DIFF
--- a/src/main/kotlin/com/chsdngm/tilly/handlers/AutosuggestionVoteHandler.kt
+++ b/src/main/kotlin/com/chsdngm/tilly/handlers/AutosuggestionVoteHandler.kt
@@ -4,7 +4,6 @@ import com.chsdngm.tilly.TelegramApi
 import com.chsdngm.tilly.config.TelegramProperties
 import com.chsdngm.tilly.model.AutosuggestionVoteUpdate
 import com.chsdngm.tilly.model.AutosuggestionVoteValue
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/com/chsdngm/tilly/handlers/MemeHandler.kt
+++ b/src/main/kotlin/com/chsdngm/tilly/handlers/MemeHandler.kt
@@ -72,7 +72,7 @@ class MemeHandler(
         }
     }
 
-    fun handle(update: AutoSuggestedMemeUpdate) = runBlocking {
+    suspend fun handle(update: AutoSuggestedMemeUpdate) {
         val file = api.download(update.fileId)
         val duplicateFileId = imageMatcher.tryFindDuplicate(file)
         if (duplicateFileId != null) {
@@ -81,7 +81,7 @@ class MemeHandler(
                 duplicateFileId = update.fileId,
                 originalFileId = duplicateFileId
             )
-            return@runBlocking
+            return
         }
 
         val message = SendPhoto().apply {

--- a/src/test/kotlin/com/chsdngm/tilly/handlers/AutosuggestionVoteHandlerTest.kt
+++ b/src/test/kotlin/com/chsdngm/tilly/handlers/AutosuggestionVoteHandlerTest.kt
@@ -5,6 +5,7 @@ import com.chsdngm.tilly.config.TelegramProperties
 import com.chsdngm.tilly.model.AutoSuggestedMemeUpdate
 import com.chsdngm.tilly.model.AutosuggestionVoteUpdate
 import com.chsdngm.tilly.model.AutosuggestionVoteValue
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.mockito.kotlin.mock
@@ -27,7 +28,7 @@ class AutosuggestionVoteHandlerTest {
     private val autosuggestionVoteHandler = AutosuggestionVoteHandler(memeHandler, api, telegramProperties)
 
     @Test
-    fun shouldHandleByMemeHandlerOnPositiveAutosuggestionDecision() {
+    fun shouldHandleByMemeHandlerOnPositiveAutosuggestionDecision() = runBlocking {
         val memeUpdate = mock(AutoSuggestedMemeUpdate::class.java)
         val update = mock<AutosuggestionVoteUpdate> {
             on(it.whoSuggests).thenReturn(mock<User>())
@@ -50,7 +51,7 @@ class AutosuggestionVoteHandlerTest {
         verify(memeHandler).handle(memeUpdate)
         verify(update).chatId
         verify(update).messageId
-        verify(api).execute(editMessageCaptionMethod)
+        verify(api).executeSuspended(editMessageCaptionMethod)
         verifyNoMoreInteractions(memeHandler, api, update)
     }
 


### PR DESCRIPTION
Сейчас автопубликация чувствительно подтормаживает 
Следующим шагом можно вынести `memeHandler.handle(memeUpdate)`  в отдельный трет пул чтобы сделать полностью асинхронным
Но даже так должно стать побыстрее немного